### PR TITLE
Add option to disable mirroring to upbound registry

### DIFF
--- a/.github/workflows/publish-provider-family.yml
+++ b/.github/workflows/publish-provider-family.yml
@@ -41,11 +41,16 @@ on:
         default: ubuntu-latest
         required: false
         type: string
+      mirror-to-upbound-registry:
+        description: "If set to true, the xpkgs will be mirrored to xpkg.upbound.io"
+        required: false
+        type: boolean
+        default: true
     secrets:
       GHCR_PAT:
         required: true
       XPKG_UPBOUND_TOKEN:
-        required: true
+        required: false # still needed if inputs.mirror-to-upbound-registry is true
 
 env:
   # Common versions
@@ -171,6 +176,7 @@ jobs:
   mirror-to-xpkg-upbound-io:
     needs: publish-artifacts
     runs-on: ${{ inputs.runs-on }}
+    if: ${{ inputs.mirror-to-upbound-registry }}
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2

--- a/.github/workflows/publish-provider-non-family.yml
+++ b/.github/workflows/publish-provider-non-family.yml
@@ -26,11 +26,16 @@ on:
         default: ubuntu-latest
         required: false
         type: string
+      mirror-to-upbound-registry:
+        description: "If set to true, the xpkg will be mirrored to xpkg.upbound.io"
+        required: false
+        type: boolean
+        default: true
     secrets:
       GHCR_PAT:
         required: true
       XPKG_UPBOUND_TOKEN:
-        required: true
+        required: false # still needed if inputs.mirror-to-upbound-registry is true
 
 env:
   # Common versions
@@ -130,6 +135,7 @@ jobs:
   mirror-to-xpkg-upbound-io:
     needs: publish-artifacts
     runs-on: ${{ inputs.runs-on }}
+    if: ${{ inputs.mirror-to-upbound-registry }}
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2


### PR DESCRIPTION
This solves #11. Adds an option to disable the job that mirrors the packages to xpkg.upbound.io, in case someone only want to push to ghcr.io/xpkg.crossplane.io.

To prevent breaking things, the default is to still mirror the xpkgs.