### PR TITLE
Use `docker login` instead of `up login` for xpkg.upbound.io

### DIFF
--- a/.github/workflows/publish-provider-non-family.yml
+++ b/.github/workflows/publish-provider-non-family.yml
@@ -26,20 +26,27 @@ on:
         default: ubuntu-latest
         required: false
         type: string
-      mirror-to-upbound-registry:
+      mirror:
         description: "If set to true, the xpkg will be mirrored to xpkg.upbound.io"
         required: false
         type: boolean
         default: true
+      mirror-registry:
+        description: "Additional registry host to mirror images to."
+        required: false
+        type: string
+        default: "xpkg.upbound.io"
       registry_org:
-        description: "The organization to publish to in the Upbound Marketplace."
+        description: "The organization to publish to in the targeted registries."
         required: false
         type: string
         default: "crossplane-contrib"
     secrets:
       GHCR_PAT:
         required: true
-      # Robot token is required if inputs.mirror-to-upbound-registry is true
+      # Additional credentials are required if inputs.mirror is set, defaulting to the common target of xpkg.upbound.io.
+      # To support an arbitrary number of additional registries, the job inputs should be refactored to accept a single string input in JSON format that can be parsed in a job step.
+      # This approach works around GitHub Actions' 10-input limit: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
       XPKG_UPBOUND_TOKEN:
         required: false
       XPKG_UPBOUND_ACCESS_ID:
@@ -48,11 +55,11 @@ on:
 env:
   # Common versions
   DOCKER_BUILDX_VERSION: 'v0.20.1'
-  UP_VERSION: 'v0.37.1'
+  UP_VERSION: 'v0.39.0'
 
   # Registry/Org names, defaulting to `crossplane-contrib`
   CROSSPLANE_REGORG: 'ghcr.io/${{ inputs.registry_org }}'
-  UPBOUND_REGORG: 'xpkg.upbound.io/${{ inputs.registry_org }}'
+  MIRROR_REGORG: '${{ inputs.mirror-registry }}/${{ inputs.registry_org }}'
 
 jobs:
   publish-artifacts:
@@ -145,12 +152,12 @@ jobs:
       - id: set
         run: |
           should_mirror=false
-          if [[ -n "${{ secrets.XPKG_UPBOUND_ACCESS_ID }}" && -n "${{ secrets.XPKG_UPBOUND_TOKEN }}" && -n "${{ inputs.mirror-to-upbound-registry }}" ]]; then
+          if [[ -n "${{ secrets.XPKG_UPBOUND_ACCESS_ID }}" && -n "${{ secrets.XPKG_UPBOUND_TOKEN }}" && -n "${{ inputs.mirror }}" ]]; then
             should_mirror=true
           fi
           echo "should_mirror=${should_mirror}" >> $GITHUB_OUTPUT
 
-  mirror-to-xpkg-upbound-io:
+  mirror-to-additional-registry:
     needs: check-prerequisites
     runs-on: ${{ inputs.runs-on }}
     if: ${{ needs.check-prerequisites.outputs.should_mirror == 'true' }}
@@ -162,13 +169,13 @@ jobs:
       - name: Validate crane installation
         run: crane version
 
-      - name: Login to Upbound
+      - name: Login to Mirror Registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
         with:
-          registry: "xpkg.upbound.io"
+          registry: ${{ inputs.mirror-registry }}
           username: ${{ secrets.XPKG_UPBOUND_ACCESS_ID }}
           password: ${{ secrets.XPKG_UPBOUND_TOKEN }}
 
-      - name: Mirror to xpkg.upbound.io
+      - name: Mirror to ${{ inputs.mirror-registry }}
         run: |
-          crane copy ${{ env.CROSSPLANE_REGORG }}/${{ inputs.repository }}:${{ inputs.version }} ${{ env.UPBOUND_REGORG }}/${{ inputs.repository }}:${{ inputs.version }} --allow-nondistributable-artifacts
+          crane copy ${{ env.CROSSPLANE_REGORG }}/${{ inputs.repository }}:${{ inputs.version }} ${{ env.MIRROR_REGORG }}/${{ inputs.repository }}:${{ inputs.version }} --allow-nondistributable-artifacts

--- a/.github/workflows/publish-provider-non-family.yml
+++ b/.github/workflows/publish-provider-non-family.yml
@@ -31,11 +31,19 @@ on:
         required: false
         type: boolean
         default: true
+      upbound_org:
+        description: "The organization to publish to in the Upbound Marketplace."
+        required: false
+        type: string
+        default: "crossplane-contrib"
     secrets:
       GHCR_PAT:
         required: true
+      # Robot token is required if inputs.mirror-to-upbound-registry is true
       XPKG_UPBOUND_TOKEN:
-        required: false # still needed if inputs.mirror-to-upbound-registry is true
+        required: false
+      XPKG_UPBOUND_ACCESS_ID:
+        required: false
 
 env:
   # Common versions
@@ -44,11 +52,7 @@ env:
 
   # Registry/Org names
   CROSSPLANE_REGORG: 'ghcr.io/crossplane-contrib' # xpkg.crossplane.io/crossplane-contrib
-  UPBOUND_REGORG: 'xpkg.upbound.io/crossplane-contrib'
-
-  # Upbound registry specific variables
-  UP_DOMAIN: "https://upbound.io"
-  UP_TOKEN: ${{ secrets.XPKG_UPBOUND_TOKEN }}
+  UPBOUND_REGORG: 'xpkg.upbound.io/${{ inputs.upbound_org }}'
 
 jobs:
   publish-artifacts:
@@ -132,10 +136,24 @@ jobs:
         run: |
           make -j XPKG_REG_ORGS="${{ env.CROSSPLANE_REGORG }}" XPKG_REG_ORGS_NO_PROMOTE="${{ env.CROSSPLANE_REGORG }}" BRANCH_NAME="main" ${{ inputs.version != '' && format('VERSION={0}', inputs.version) || '' }} publish
 
-  mirror-to-xpkg-upbound-io:
+  check-prerequisites:
     needs: publish-artifacts
     runs-on: ${{ inputs.runs-on }}
-    if: ${{ inputs.mirror-to-upbound-registry }}
+    outputs:
+      should_mirror: ${{ steps.set.outputs.should_mirror }}
+    steps:
+      - id: set
+        run: |
+          should_mirror=false
+          if [[ -n "${{ secrets.XPKG_UPBOUND_ACCESS_ID }}" && -n "${{ secrets.XPKG_UPBOUND_TOKEN }}" && -n "${{ inputs.mirror-to-upbound-registry }}" ]]; then
+            should_mirror=true
+          fi
+          echo "should_mirror=${should_mirror}" >> $GITHUB_OUTPUT
+
+  mirror-to-xpkg-upbound-io:
+    needs: check-prerequisites
+    runs-on: ${{ inputs.runs-on }}
+    if: ${{ needs.check-prerequisites.outputs.should_mirror == 'true' }}
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
@@ -155,31 +173,12 @@ jobs:
       - name: Validate crane installation
         run: crane version
 
-      - name: Up Login
-        run: |
-          curl -fsSLo /tmp/up --create-dirs 'https://cli.upbound.io/stable/${{ env.UP_VERSION }}/bin/linux_amd64/up' && \
-          chmod +x /tmp/up && \
-          /tmp/up login
-
-      - name: Install docker-credential-up
-        run: |
-          curl -fsSLo /tmp/docker-credential-up --create-dirs 'https://cli.upbound.io/stable/${{ env.UP_VERSION }}/bin/linux_amd64/docker-credential-up' && \
-          chmod +x /tmp/docker-credential-up && \
-          sudo mv /tmp/docker-credential-up /usr/local/bin/docker-credential-up
-
-      - name: Get creds
-        run: |
-          echo "${{ env.UP_DOMAIN }}" | docker-credential-up get > $HOME/.up/up.token.json
-          echo "DOCKER_USERNAME=$(cat $HOME/.up/up.token.json | jq -r '.Username')" >> $GITHUB_ENV
-          echo "DOCKER_PWD=$(cat $HOME/.up/up.token.json | jq -r '.Secret')" >> $GITHUB_ENV
-
       - name: Login to Upbound
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-        if: env.DOCKER_USERNAME != ''
         with:
           registry: "xpkg.upbound.io"
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PWD }}
+          username: ${{ secrets.XPKG_UPBOUND_ACCESS_ID }}
+          password: ${{ secrets.XPKG_UPBOUND_TOKEN }}
 
       - name: Mirror to xpkg.upbound.io
         run: |

--- a/.github/workflows/publish-provider-non-family.yml
+++ b/.github/workflows/publish-provider-non-family.yml
@@ -27,7 +27,7 @@ on:
         required: false
         type: string
       mirror:
-        description: "If set to true, the xpkg will be mirrored to xpkg.upbound.io"
+        description: "If set to true, the image will be mirrored to the specified mirror-registry."
         required: false
         type: boolean
         default: true
@@ -47,9 +47,9 @@ on:
       # Additional credentials are required if inputs.mirror is set, defaulting to the common target of xpkg.upbound.io.
       # To support an arbitrary number of additional registries, the job inputs should be refactored to accept a single string input in JSON format that can be parsed in a job step.
       # This approach works around GitHub Actions' 10-input limit: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
-      XPKG_UPBOUND_TOKEN:
+      XPKG_MIRROR_TOKEN:
         required: false
-      XPKG_UPBOUND_ACCESS_ID:
+      XPKG_MIRROR_ACCESS_ID:
         required: false
 
 env:
@@ -152,7 +152,7 @@ jobs:
       - id: set
         run: |
           should_mirror=false
-          if [[ -n "${{ secrets.XPKG_UPBOUND_ACCESS_ID }}" && -n "${{ secrets.XPKG_UPBOUND_TOKEN }}" && -n "${{ inputs.mirror }}" ]]; then
+          if [[ -n "${{ secrets.XPKG_MIRROR_ACCESS_ID }}" && -n "${{ secrets.XPKG_MIRROR_TOKEN }}" && -n "${{ inputs.mirror }}" ]]; then
             should_mirror=true
           fi
           echo "should_mirror=${should_mirror}" >> $GITHUB_OUTPUT
@@ -173,8 +173,8 @@ jobs:
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
         with:
           registry: ${{ inputs.mirror-registry }}
-          username: ${{ secrets.XPKG_UPBOUND_ACCESS_ID }}
-          password: ${{ secrets.XPKG_UPBOUND_TOKEN }}
+          username: ${{ secrets.XPKG_MIRROR_ACCESS_ID }}
+          password: ${{ secrets.XPKG_MIRROR_TOKEN }}
 
       - name: Mirror to ${{ inputs.mirror-registry }}
         run: |

--- a/.github/workflows/publish-provider-non-family.yml
+++ b/.github/workflows/publish-provider-non-family.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: boolean
         default: true
-      upbound_org:
+      registry_org:
         description: "The organization to publish to in the Upbound Marketplace."
         required: false
         type: string
@@ -50,9 +50,9 @@ env:
   DOCKER_BUILDX_VERSION: 'v0.20.1'
   UP_VERSION: 'v0.37.1'
 
-  # Registry/Org names
-  CROSSPLANE_REGORG: 'ghcr.io/crossplane-contrib' # xpkg.crossplane.io/crossplane-contrib
-  UPBOUND_REGORG: 'xpkg.upbound.io/${{ inputs.upbound_org }}'
+  # Registry/Org names, defaulting to `crossplane-contrib`
+  CROSSPLANE_REGORG: 'ghcr.io/${{ inputs.registry_org }}'
+  UPBOUND_REGORG: 'xpkg.upbound.io/${{ inputs.registry_org }}'
 
 jobs:
   publish-artifacts:

--- a/.github/workflows/publish-provider-non-family.yml
+++ b/.github/workflows/publish-provider-non-family.yml
@@ -155,17 +155,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ needs.check-prerequisites.outputs.should_mirror == 'true' }}
     steps:
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
-        with:
-          platforms: all
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
-        with:
-          version: ${{ env.DOCKER_BUILDX_VERSION }}
-          install: true
-
       - name: Setup crane
         # crane will inherit credentials from `docker login`
         uses: imjasonh/setup-crane@v0.4


### PR DESCRIPTION
Fixes #14 for non-family providers. See [comment](https://github.com/crossplane-contrib/provider-workflows/issues/14#issuecomment-2970057968) for additional context.

This will also enable repositories outside of `crossplane-contrib` to use the reusable workflow, and the repository owner can set their own robot token as the secret values. For repositories in `crossplane-contrib`, the secrets would have to be set by someone with access to the `crossplane-contrib` organization in Upbound.

## How this has been tested:

Scenario 1: backwards compatibility (skip publishing if access ID not provided): https://github.com/jastang/provider-kubernetes/actions/runs/15640349626

Scenario 2: successful publishing when all secrets provided: https://github.com/jastang/provider-kubernetes/actions/runs/15640461074/job/44066401578

ghcr.io: https://github.com/jastang/provider-kubernetes/pkgs/container/provider-kubernetes
xpkg.upbound.io: https://explore.ggcr.dev/?repo=xpkg.upbound.io/jastang/provider-kubernetes (only scenario 2)