### PR TITLE
Mirror packages to xpkg.upbound.io in parallel

### DIFF
--- a/.github/workflows/publish-provider-family.yml
+++ b/.github/workflows/publish-provider-family.yml
@@ -55,20 +55,10 @@ on:
 env:
   # Common versions
   DOCKER_BUILDX_VERSION: 'v0.20.1'
-  UP_VERSION: 'v0.37.1'
 
   # Registry/Org names
   CROSSPLANE_REGORG: 'ghcr.io/crossplane-contrib' # xpkg.crossplane.io/crossplane-contrib
-  UPBOUND_REGORG: 'xpkg.upbound.io/crossplane-contrib'
   CROSSPLANE_PROXY_REGORG: 'xpkg.crossplane.io/crossplane-contrib'
-
-  # Upbound registry specific variables
-  UP_DOMAIN: "https://upbound.io"
-  UP_TOKEN: ${{ secrets.XPKG_UPBOUND_TOKEN }}
-
-  # retry configuration
-  RETRY_COUNT: 10
-  RETRY_DELAY: 30
 
 jobs:
   index:
@@ -177,69 +167,11 @@ jobs:
         run: |
           make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS="${{ env.CROSSPLANE_REGORG }}" XPKG_REG_ORGS_NO_PROMOTE="${{ env.CROSSPLANE_REGORG }}" CONFIG_DEPENDENCY_REG_ORG="${{ env.CROSSPLANE_PROXY_REGORG }}" CONCURRENCY="${{ inputs.concurrency }}" BRANCH_NAME="main" ${{ inputs.version != '' && format('VERSION={0}', inputs.version) || '' }} publish
 
-  mirror-to-xpkg-upbound-io:
-    needs: publish-artifacts
-    runs-on: ${{ inputs.runs-on }}
-    if: ${{ inputs.mirror-to-upbound-registry }}
-    steps:
-      - name: Setup crane
-        # crane will inherit credentials from `docker login`
-        uses: imjasonh/setup-crane@v0.4
-
-      - name: Validate crane installation
-        run: crane version
-
-      - name: Up Login
-        run: |
-          curl -fsSLo /tmp/up --create-dirs 'https://cli.upbound.io/stable/${{ env.UP_VERSION }}/bin/linux_amd64/up' && \
-          chmod +x /tmp/up && \
-          /tmp/up login
-
-      - name: Install docker-credential-up
-        run: |
-          curl -fsSLo /tmp/docker-credential-up --create-dirs 'https://cli.upbound.io/stable/${{ env.UP_VERSION }}/bin/linux_amd64/docker-credential-up' && \
-          chmod +x /tmp/docker-credential-up && \
-          sudo mv /tmp/docker-credential-up /usr/local/bin/docker-credential-up
-
-      - name: Get creds
-        run: |
-          echo "${{ env.UP_DOMAIN }}" | docker-credential-up get > $HOME/.up/up.token.json
-          echo "DOCKER_USERNAME=$(cat $HOME/.up/up.token.json | jq -r '.Username')" >> $GITHUB_ENV
-          echo "DOCKER_PWD=$(cat $HOME/.up/up.token.json | jq -r '.Secret')" >> $GITHUB_ENV
-
-      - name: Login to Upbound
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-        if: env.DOCKER_USERNAME != ''
-        with:
-          registry: "xpkg.upbound.io"
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PWD }}
-
       - name: Mirror to xpkg.upbound.io
-        run: |
-          for subpackage in ${{ inputs.subpackages }}; do
-            p="${{ inputs.repository }}-$subpackage"
-            if [ "$subpackage" = "config" ]; then
-              p="provider-family-$(echo ${{ inputs.repository }} | sed 's/provider-//')"
-            fi
-
-            attempt=1
-            success=0
-            while [ $attempt -le ${{ env.RETRY_COUNT }} ]; do
-              echo "Attempt $attempt/${{ env.RETRY_COUNT }}: copying ${{ env.CROSSPLANE_REGORG }}/$p:${{ inputs.version }} -> ${{ env.UPBOUND_REGORG }}/$p:${{ inputs.version }}"
-              if crane copy "${{ env.CROSSPLANE_REGORG }}/$p:${{ inputs.version }}" "${{ env.UPBOUND_REGORG }}/$p:${{ inputs.version }}" --allow-nondistributable-artifacts; then
-                success=1
-                break
-              fi
-              attempt=$((attempt + 1))
-              if [ $attempt -le ${{ env.RETRY_COUNT }} ]; then
-                echo "Copy failed, retrying in ${{ env.RETRY_DELAY }}s..."
-                sleep ${{ env.RETRY_DELAY }}
-              fi
-            done
-
-            if [ $success -ne 1 ]; then
-              echo "ERROR: Failed to mirror $p after ${{ env.RETRY_COUNT }} attempts." >&2
-              exit 1
-            fi
-          done
+        if: ${{ inputs.mirror-to-upbound-registry }}
+        uses: ./.github/actions/mirror-to-xpkg-upbound-io
+        with:
+          subpackages: ${{ steps.packages.outputs.target }}
+          repository: ${{ inputs.repository }}
+          version: ${{ inputs.version }}
+          xpkg-upbound-token: ${{ secrets.XPKG_UPBOUND_TOKEN }}

--- a/.github/workflows/publish-provider-family.yml
+++ b/.github/workflows/publish-provider-family.yml
@@ -64,19 +64,29 @@ jobs:
   index:
     runs-on: ${{ inputs.runs-on }}
     outputs:
+      subpackages: ${{ steps.calc_subpackages.outputs.subpackages }}
       indices: ${{ steps.calc.outputs.indices }}
     steps:
+      - name: Get provider subpackages
+        id: calc_subpackages
+        uses: crossplane-contrib/provider-workflows/.github/actions/get-provider-subpackages@4b68054c68e748195624fcf8187886a1123fc7a2
+        with:
+          provider: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          subpackages_str: ${{ inputs.subpackages }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - id: calc
         run: |
-          python3 -c "import math; print(f'indices={list(range(0, math.ceil(len(\"${{ inputs.subpackages }}\".split()) / int(\"${{ inputs.size }}\"))))}')" >> "$GITHUB_OUTPUT"
+          python3 -c "import math; print(f'indices={list(range(0, math.ceil(len(\"${{ steps.calc_subpackages.outputs.subpackages }}\".split()) / int(\"${{ inputs.size }}\"))))}')" >> "$GITHUB_OUTPUT"
 
   publish-artifacts:
+    needs: index
+    runs-on: ${{ inputs.runs-on }}
     strategy:
       matrix:
         index: ${{ fromJSON(needs.index.outputs.indices) }}
 
-    needs: index
-    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -146,7 +156,7 @@ jobs:
       - name: Calculate packages to build & push
         id: packages
         run: |
-          echo target=$(python3 -c "print(' '.join(\"${{ inputs.subpackages }}\".split()[int(\"${{ matrix.index }}\") * int(\"${{ inputs.size }}\"): (int(\"${{ matrix.index }}\")+1) * int(\"${{ inputs.size }}\")]))") >> "$GITHUB_OUTPUT"
+          echo target=$(python3 -c "print(' '.join(\"${{ needs.index.outputs.subpackages }}\".split()[int(\"${{ matrix.index }}\") * int(\"${{ inputs.size }}\"): (int(\"${{ matrix.index }}\")+1) * int(\"${{ inputs.size }}\")]))") >> "$GITHUB_OUTPUT"
 
       - name: Build Artifacts
         id: build_artifacts
@@ -169,7 +179,7 @@ jobs:
 
       - name: Mirror to xpkg.upbound.io
         if: ${{ inputs.mirror-to-upbound-registry }}
-        uses: ./.github/actions/mirror-to-xpkg-upbound-io
+        uses: crossplane-contrib/provider-workflows/.github/actions/mirror-to-xpkg-upbound-io@4b68054c68e748195624fcf8187886a1123fc7a2
         with:
           subpackages: ${{ steps.packages.outputs.target }}
           repository: ${{ inputs.repository }}


### PR DESCRIPTION
## Related

- Previous PR: #21 - Added retry mechanism for `crane copy` operations
- Builds on: #22 - "Get Provider Subpackages" composite action

## Summary

Parallelizes the mirroring of Crossplane packages to `xpkg.upbound.io` by moving the mirror operation into each matrix job, allowing multiple subsets of packages to be mirrored concurrently instead of sequentially.

## Motivation

Previously, package mirroring occurred in a separate job (`mirror-to-xpkg-upbound-io`) that ran after all `publish-artifacts` matrix jobs completed. This job mirrored **all** packages sequentially, creating a bottleneck in the publishing pipeline.

For large provider families with many packages:
- Sequential mirroring could take significant time
- The workflow waited for all builds to complete before starting any mirroring
- Network operations were not parallelized

## Changes

### 1. New Composite Action
Created `.github/actions/mirror-to-xpkg-upbound-io/action.yml`:
- Encapsulates the mirror logic with proper input parameters
- Maintains the existing retry mechanism (10 attempts, 30s delay by default)
- Adds configurability through inputs with sensible defaults
- Includes defensive handling for empty package lists

### 2. Workflow Refactoring
Modified `.github/workflows/publish-provider-family.yml`:
- Removed the separate `mirror-to-xpkg-upbound-io` job
- Added mirror step to each `publish-artifacts` matrix job
- Each job now mirrors only its assigned subset of packages (`steps.packages.outputs.target`)
- Removed now-unused environment variables (`UP_VERSION`, `UPBOUND_REGORG`, `UP_DOMAIN`, `UP_TOKEN`, `RETRY_COUNT`, `RETRY_DELAY`)
- `publish-provider-family.yml` now uses the composite action `get-provider-subpackages` introduced with #22 and thus supports wildcard expansion if the caller provider repository supports it.

## Performance Impact

For a provider family with **M** packages split across **N** matrix jobs:
- **Before**: M packages mirrored sequentially
- **After**: M packages mirrored across N parallel jobs (~M/N packages each)
- **Expected speedup**: ~N× for the mirroring phase (network-bound operations)

## Backward Compatibility

✅ **Fully backward compatible**:
- All workflow inputs remain unchanged
- All secrets remain unchanged
- Existing callers require no modifications
- Same behavior when `mirror-to-upbound-registry: false`

## Retry Mechanism

✅ **Fully preserved**:
- Same retry logic with 10 attempts by default
- Same 30-second delay between retries
- Same error handling (exits on failure after max attempts)
- Now configurable via action inputs if needed

## Testing
✅  **With wildcard expansion**: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/19344185546/job/55340119486
- Wildcard is expanded into all family members:
<img width="1690" height="888" alt="image" src="https://github.com/user-attachments/assets/73103371-a9aa-4a0e-9fd6-abece780bcfa" />
- Mirroring is now parallelized:
<img width="1705" height="881" alt="image" src="https://github.com/user-attachments/assets/1dddd27c-f9d8-4e88-9404-afac0cba03e7" />

✅  **Without wildcard expansion**: https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/19344268157/job/55340411740
<img width="1700" height="891" alt="image" src="https://github.com/user-attachments/assets/393cc1dd-8a43-4552-bc0a-8505b4881a4e" />

